### PR TITLE
Repos form

### DIFF
--- a/app/controllers/repos/search_controller.rb
+++ b/app/controllers/repos/search_controller.rb
@@ -1,0 +1,4 @@
+class Repos::SearchController < BaseController
+  def index
+  end
+end

--- a/app/controllers/repos/search_controller.rb
+++ b/app/controllers/repos/search_controller.rb
@@ -1,22 +1,8 @@
 class Repos::SearchController < BaseController
-  def create
-    @repos_found = find_github_repos(current_user.login, params[:search])
-    render 'repos/index'
+  def index
+    render locals: {
+      repos_found: GitHubReposFacade.new(current_user.login, params[:search])
+    }, template: "repos/index"
   end
 
-  def find_github_repos(user_login, search_term)
-    # Make real api call to give back a list of repos
-    # mock_repos_found = [
-    #   {
-    #     repo_name: 'monster_shop_1908',
-    #     owner: 'mockuser',
-    #     repo_id: 26877629,
-    #   },
-    #   {
-    #     repo_name: 'monster_shop_final',
-    #     owner: 'mockuser',
-    #     repo_id: 99999988,
-    #   },
-    # ]
-  end
 end

--- a/app/controllers/repos/search_controller.rb
+++ b/app/controllers/repos/search_controller.rb
@@ -1,4 +1,22 @@
 class Repos::SearchController < BaseController
-  def index
+  def create
+    @repos_found = find_github_repos(current_user.login, params[:search])
+    render 'repos/index'
+  end
+
+  def find_github_repos(user_login, search_term)
+    # Make real api call to give back a list of repos
+    # mock_repos_found = [
+    #   {
+    #     repo_name: 'monster_shop_1908',
+    #     owner: 'mockuser',
+    #     repo_id: 26877629,
+    #   },
+    #   {
+    #     repo_name: 'monster_shop_final',
+    #     owner: 'mockuser',
+    #     repo_id: 99999988,
+    #   },
+    # ]
   end
 end

--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -1,4 +1,5 @@
 class ReposController < BaseController
   def index
+    render locals: { repos_found: nil}
   end
 end

--- a/app/facades/git_hub_repos_facade.rb
+++ b/app/facades/git_hub_repos_facade.rb
@@ -1,0 +1,18 @@
+class GitHubReposFacade
+  def initialize(login, search_term)
+    @login = login
+    @search_term = search_term
+  end
+
+  def repos
+    service = GitHubService.new
+    @repos_data ||= service.find_repos(login, search_term)
+
+    @repos_data[:items].map do |info|
+      Repo.new(info)
+    end
+  end
+
+  private
+  attr_reader :login, :search_term
+end

--- a/app/poros/repo.rb
+++ b/app/poros/repo.rb
@@ -1,0 +1,7 @@
+class Repo
+  attr_reader :name
+  
+  def initialize(info)
+    @name = info[:name]
+  end
+end

--- a/app/services/git_hub_service.rb
+++ b/app/services/git_hub_service.rb
@@ -1,0 +1,18 @@
+class GitHubService
+
+  def find_repos(login, search_term)
+    response = conn.get(generate_uri(login, search_term, 'search/repositories'))
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def conn
+    Faraday.new(url: 'https://api.github.com') do |f|
+      f.adapter Faraday.default_adapter
+    end
+  end
+
+  def generate_uri(login, search_term, uri)
+    "search/repositories?q=#{search_term}+in:name+user:#{login}+fork:true"
+  end
+
+end

--- a/app/views/repos/index.html.erb
+++ b/app/views/repos/index.html.erb
@@ -3,3 +3,13 @@
   find a repo <%= text_field_tag :search %>
   <%= submit_tag 'search' %>
 <% end %>
+
+<% if @repos_found %>
+  <section class="found-repos">
+    <% @repos_found.each do |repo| %>
+      <ul>
+        <li><%= repo[:repo_name] %></li>
+      </ul>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/repos/index.html.erb
+++ b/app/views/repos/index.html.erb
@@ -1,1 +1,5 @@
-<h1>Repos Page!</h1>
+<h1>search for a repo</h1>
+<%= form_tag(repos_search_path) do %>
+  find a repo <%= text_field_tag :search %>
+  <%= submit_tag 'search' %>
+<% end %>

--- a/app/views/repos/index.html.erb
+++ b/app/views/repos/index.html.erb
@@ -1,14 +1,14 @@
 <h1>search for a repo</h1>
-<%= form_tag(repos_search_path) do %>
+<%= form_tag(repos_search_path, method: :get) do %>
   find a repo <%= text_field_tag :search %>
   <%= submit_tag 'search' %>
 <% end %>
 
-<% if @repos_found %>
+<% if repos_found && !repos_found.repos.empty? %>
   <section class="found-repos">
-    <% @repos_found.each do |repo| %>
+    <% repos_found.repos.each do |repo| %>
       <ul>
-        <li><%= repo[:repo_name] %></li>
+        <li><%= repo.name %></li>
       </ul>
     <% end %>
   </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get '/auth/failure', to: 'sessions#failure'
 
   get '/repos', to: 'repos#index'
-  get '/repos_search', to: 'repos/search#index', as: 'repos_search'
+  post '/repos_search', to: 'repos/search#create', as: 'repos_search'
 
   delete '/logout', to: 'sessions#destroy'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get '/auth/failure', to: 'sessions#failure'
 
   get '/repos', to: 'repos#index'
+  get '/repos_search', to: 'repos/search#index', as: 'repos_search'
 
   delete '/logout', to: 'sessions#destroy'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get '/auth/failure', to: 'sessions#failure'
 
   get '/repos', to: 'repos#index'
-  post '/repos_search', to: 'repos/search#create', as: 'repos_search'
+  get '/repos_search', to: 'repos/search#index', as: 'repos_search'
 
   delete '/logout', to: 'sessions#destroy'
 end

--- a/spec/cassettes/A_signed_in_User_can_search_for_their_repos/can_search_for_a_list_of_repos.yml
+++ b/spec/cassettes/A_signed_in_User_can_search_for_their_repos/can_search_for_a_list_of_repos.yml
@@ -1,0 +1,129 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/search/repositories?q=monster_shop%20in:name%20user:ap2322%20fork:true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Sat, 21 Dec 2019 00:12:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1576887222'
+      Cache-Control:
+      - no-cache
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - EB50:22AC:9094A9:168B64E:5DFD637A
+    body:
+      encoding: ASCII-8BIT
+      string: '{"total_count":2,"incomplete_results":false,"items":[{"id":218847867,"node_id":"MDEwOlJlcG9zaXRvcnkyMTg4NDc4Njc=","name":"monster_shop_final","full_name":"ap2322/monster_shop_final","private":false,"owner":{"login":"ap2322","id":26877629,"node_id":"MDQ6VXNlcjI2ODc3NjI5","avatar_url":"https://avatars0.githubusercontent.com/u/26877629?v=4","gravatar_id":"","url":"https://api.github.com/users/ap2322","html_url":"https://github.com/ap2322","followers_url":"https://api.github.com/users/ap2322/followers","following_url":"https://api.github.com/users/ap2322/following{/other_user}","gists_url":"https://api.github.com/users/ap2322/gists{/gist_id}","starred_url":"https://api.github.com/users/ap2322/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ap2322/subscriptions","organizations_url":"https://api.github.com/users/ap2322/orgs","repos_url":"https://api.github.com/users/ap2322/repos","events_url":"https://api.github.com/users/ap2322/events{/privacy}","received_events_url":"https://api.github.com/users/ap2322/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ap2322/monster_shop_final","description":null,"fork":false,"url":"https://api.github.com/repos/ap2322/monster_shop_final","forks_url":"https://api.github.com/repos/ap2322/monster_shop_final/forks","keys_url":"https://api.github.com/repos/ap2322/monster_shop_final/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ap2322/monster_shop_final/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ap2322/monster_shop_final/teams","hooks_url":"https://api.github.com/repos/ap2322/monster_shop_final/hooks","issue_events_url":"https://api.github.com/repos/ap2322/monster_shop_final/issues/events{/number}","events_url":"https://api.github.com/repos/ap2322/monster_shop_final/events","assignees_url":"https://api.github.com/repos/ap2322/monster_shop_final/assignees{/user}","branches_url":"https://api.github.com/repos/ap2322/monster_shop_final/branches{/branch}","tags_url":"https://api.github.com/repos/ap2322/monster_shop_final/tags","blobs_url":"https://api.github.com/repos/ap2322/monster_shop_final/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ap2322/monster_shop_final/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ap2322/monster_shop_final/git/refs{/sha}","trees_url":"https://api.github.com/repos/ap2322/monster_shop_final/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ap2322/monster_shop_final/statuses/{sha}","languages_url":"https://api.github.com/repos/ap2322/monster_shop_final/languages","stargazers_url":"https://api.github.com/repos/ap2322/monster_shop_final/stargazers","contributors_url":"https://api.github.com/repos/ap2322/monster_shop_final/contributors","subscribers_url":"https://api.github.com/repos/ap2322/monster_shop_final/subscribers","subscription_url":"https://api.github.com/repos/ap2322/monster_shop_final/subscription","commits_url":"https://api.github.com/repos/ap2322/monster_shop_final/commits{/sha}","git_commits_url":"https://api.github.com/repos/ap2322/monster_shop_final/git/commits{/sha}","comments_url":"https://api.github.com/repos/ap2322/monster_shop_final/comments{/number}","issue_comment_url":"https://api.github.com/repos/ap2322/monster_shop_final/issues/comments{/number}","contents_url":"https://api.github.com/repos/ap2322/monster_shop_final/contents/{+path}","compare_url":"https://api.github.com/repos/ap2322/monster_shop_final/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ap2322/monster_shop_final/merges","archive_url":"https://api.github.com/repos/ap2322/monster_shop_final/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ap2322/monster_shop_final/downloads","issues_url":"https://api.github.com/repos/ap2322/monster_shop_final/issues{/number}","pulls_url":"https://api.github.com/repos/ap2322/monster_shop_final/pulls{/number}","milestones_url":"https://api.github.com/repos/ap2322/monster_shop_final/milestones{/number}","notifications_url":"https://api.github.com/repos/ap2322/monster_shop_final/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ap2322/monster_shop_final/labels{/name}","releases_url":"https://api.github.com/repos/ap2322/monster_shop_final/releases{/id}","deployments_url":"https://api.github.com/repos/ap2322/monster_shop_final/deployments","created_at":"2019-10-31T19:45:19Z","updated_at":"2019-12-05T16:09:58Z","pushed_at":"2019-12-20T07:07:11Z","git_url":"git://github.com/ap2322/monster_shop_final.git","ssh_url":"git@github.com:ap2322/monster_shop_final.git","clone_url":"https://github.com/ap2322/monster_shop_final.git","svn_url":"https://github.com/ap2322/monster_shop_final","homepage":null,"size":239,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":3,"license":null,"forks":0,"open_issues":3,"watchers":0,"default_branch":"master","score":16.979485},{"id":216670989,"node_id":"MDEwOlJlcG9zaXRvcnkyMTY2NzA5ODk=","name":"monster_shop_1908","full_name":"ap2322/monster_shop_1908","private":false,"owner":{"login":"ap2322","id":26877629,"node_id":"MDQ6VXNlcjI2ODc3NjI5","avatar_url":"https://avatars0.githubusercontent.com/u/26877629?v=4","gravatar_id":"","url":"https://api.github.com/users/ap2322","html_url":"https://github.com/ap2322","followers_url":"https://api.github.com/users/ap2322/followers","following_url":"https://api.github.com/users/ap2322/following{/other_user}","gists_url":"https://api.github.com/users/ap2322/gists{/gist_id}","starred_url":"https://api.github.com/users/ap2322/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ap2322/subscriptions","organizations_url":"https://api.github.com/users/ap2322/orgs","repos_url":"https://api.github.com/users/ap2322/repos","events_url":"https://api.github.com/users/ap2322/events{/privacy}","received_events_url":"https://api.github.com/users/ap2322/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ap2322/monster_shop_1908","description":null,"fork":true,"url":"https://api.github.com/repos/ap2322/monster_shop_1908","forks_url":"https://api.github.com/repos/ap2322/monster_shop_1908/forks","keys_url":"https://api.github.com/repos/ap2322/monster_shop_1908/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ap2322/monster_shop_1908/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ap2322/monster_shop_1908/teams","hooks_url":"https://api.github.com/repos/ap2322/monster_shop_1908/hooks","issue_events_url":"https://api.github.com/repos/ap2322/monster_shop_1908/issues/events{/number}","events_url":"https://api.github.com/repos/ap2322/monster_shop_1908/events","assignees_url":"https://api.github.com/repos/ap2322/monster_shop_1908/assignees{/user}","branches_url":"https://api.github.com/repos/ap2322/monster_shop_1908/branches{/branch}","tags_url":"https://api.github.com/repos/ap2322/monster_shop_1908/tags","blobs_url":"https://api.github.com/repos/ap2322/monster_shop_1908/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ap2322/monster_shop_1908/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ap2322/monster_shop_1908/git/refs{/sha}","trees_url":"https://api.github.com/repos/ap2322/monster_shop_1908/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ap2322/monster_shop_1908/statuses/{sha}","languages_url":"https://api.github.com/repos/ap2322/monster_shop_1908/languages","stargazers_url":"https://api.github.com/repos/ap2322/monster_shop_1908/stargazers","contributors_url":"https://api.github.com/repos/ap2322/monster_shop_1908/contributors","subscribers_url":"https://api.github.com/repos/ap2322/monster_shop_1908/subscribers","subscription_url":"https://api.github.com/repos/ap2322/monster_shop_1908/subscription","commits_url":"https://api.github.com/repos/ap2322/monster_shop_1908/commits{/sha}","git_commits_url":"https://api.github.com/repos/ap2322/monster_shop_1908/git/commits{/sha}","comments_url":"https://api.github.com/repos/ap2322/monster_shop_1908/comments{/number}","issue_comment_url":"https://api.github.com/repos/ap2322/monster_shop_1908/issues/comments{/number}","contents_url":"https://api.github.com/repos/ap2322/monster_shop_1908/contents/{+path}","compare_url":"https://api.github.com/repos/ap2322/monster_shop_1908/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ap2322/monster_shop_1908/merges","archive_url":"https://api.github.com/repos/ap2322/monster_shop_1908/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ap2322/monster_shop_1908/downloads","issues_url":"https://api.github.com/repos/ap2322/monster_shop_1908/issues{/number}","pulls_url":"https://api.github.com/repos/ap2322/monster_shop_1908/pulls{/number}","milestones_url":"https://api.github.com/repos/ap2322/monster_shop_1908/milestones{/number}","notifications_url":"https://api.github.com/repos/ap2322/monster_shop_1908/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ap2322/monster_shop_1908/labels{/name}","releases_url":"https://api.github.com/repos/ap2322/monster_shop_1908/releases{/id}","deployments_url":"https://api.github.com/repos/ap2322/monster_shop_1908/deployments","created_at":"2019-10-21T21:45:25Z","updated_at":"2019-10-31T02:27:27Z","pushed_at":"2019-10-31T02:27:24Z","git_url":"git://github.com/ap2322/monster_shop_1908.git","ssh_url":"git@github.com:ap2322/monster_shop_1908.git","clone_url":"https://github.com/ap2322/monster_shop_1908.git","svn_url":"https://github.com/ap2322/monster_shop_1908","homepage":null,"size":410,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","score":13.544703}]}'
+    http_version: 
+  recorded_at: Sat, 21 Dec 2019 00:12:42 GMT
+- request:
+    method: get
+    uri: https://api.github.com/search/repositories?q=monster_shop%20in:name%20user:ap2322%20fork:true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Sat, 21 Dec 2019 00:12:43 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1576887222'
+      Cache-Control:
+      - no-cache
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - EB51:3683:1162781:2514008:5DFD637A
+    body:
+      encoding: ASCII-8BIT
+      string: '{"total_count":2,"incomplete_results":false,"items":[{"id":218847867,"node_id":"MDEwOlJlcG9zaXRvcnkyMTg4NDc4Njc=","name":"monster_shop_final","full_name":"ap2322/monster_shop_final","private":false,"owner":{"login":"ap2322","id":26877629,"node_id":"MDQ6VXNlcjI2ODc3NjI5","avatar_url":"https://avatars0.githubusercontent.com/u/26877629?v=4","gravatar_id":"","url":"https://api.github.com/users/ap2322","html_url":"https://github.com/ap2322","followers_url":"https://api.github.com/users/ap2322/followers","following_url":"https://api.github.com/users/ap2322/following{/other_user}","gists_url":"https://api.github.com/users/ap2322/gists{/gist_id}","starred_url":"https://api.github.com/users/ap2322/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ap2322/subscriptions","organizations_url":"https://api.github.com/users/ap2322/orgs","repos_url":"https://api.github.com/users/ap2322/repos","events_url":"https://api.github.com/users/ap2322/events{/privacy}","received_events_url":"https://api.github.com/users/ap2322/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ap2322/monster_shop_final","description":null,"fork":false,"url":"https://api.github.com/repos/ap2322/monster_shop_final","forks_url":"https://api.github.com/repos/ap2322/monster_shop_final/forks","keys_url":"https://api.github.com/repos/ap2322/monster_shop_final/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ap2322/monster_shop_final/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ap2322/monster_shop_final/teams","hooks_url":"https://api.github.com/repos/ap2322/monster_shop_final/hooks","issue_events_url":"https://api.github.com/repos/ap2322/monster_shop_final/issues/events{/number}","events_url":"https://api.github.com/repos/ap2322/monster_shop_final/events","assignees_url":"https://api.github.com/repos/ap2322/monster_shop_final/assignees{/user}","branches_url":"https://api.github.com/repos/ap2322/monster_shop_final/branches{/branch}","tags_url":"https://api.github.com/repos/ap2322/monster_shop_final/tags","blobs_url":"https://api.github.com/repos/ap2322/monster_shop_final/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ap2322/monster_shop_final/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ap2322/monster_shop_final/git/refs{/sha}","trees_url":"https://api.github.com/repos/ap2322/monster_shop_final/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ap2322/monster_shop_final/statuses/{sha}","languages_url":"https://api.github.com/repos/ap2322/monster_shop_final/languages","stargazers_url":"https://api.github.com/repos/ap2322/monster_shop_final/stargazers","contributors_url":"https://api.github.com/repos/ap2322/monster_shop_final/contributors","subscribers_url":"https://api.github.com/repos/ap2322/monster_shop_final/subscribers","subscription_url":"https://api.github.com/repos/ap2322/monster_shop_final/subscription","commits_url":"https://api.github.com/repos/ap2322/monster_shop_final/commits{/sha}","git_commits_url":"https://api.github.com/repos/ap2322/monster_shop_final/git/commits{/sha}","comments_url":"https://api.github.com/repos/ap2322/monster_shop_final/comments{/number}","issue_comment_url":"https://api.github.com/repos/ap2322/monster_shop_final/issues/comments{/number}","contents_url":"https://api.github.com/repos/ap2322/monster_shop_final/contents/{+path}","compare_url":"https://api.github.com/repos/ap2322/monster_shop_final/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ap2322/monster_shop_final/merges","archive_url":"https://api.github.com/repos/ap2322/monster_shop_final/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ap2322/monster_shop_final/downloads","issues_url":"https://api.github.com/repos/ap2322/monster_shop_final/issues{/number}","pulls_url":"https://api.github.com/repos/ap2322/monster_shop_final/pulls{/number}","milestones_url":"https://api.github.com/repos/ap2322/monster_shop_final/milestones{/number}","notifications_url":"https://api.github.com/repos/ap2322/monster_shop_final/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ap2322/monster_shop_final/labels{/name}","releases_url":"https://api.github.com/repos/ap2322/monster_shop_final/releases{/id}","deployments_url":"https://api.github.com/repos/ap2322/monster_shop_final/deployments","created_at":"2019-10-31T19:45:19Z","updated_at":"2019-12-05T16:09:58Z","pushed_at":"2019-12-20T07:07:11Z","git_url":"git://github.com/ap2322/monster_shop_final.git","ssh_url":"git@github.com:ap2322/monster_shop_final.git","clone_url":"https://github.com/ap2322/monster_shop_final.git","svn_url":"https://github.com/ap2322/monster_shop_final","homepage":null,"size":239,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":3,"license":null,"forks":0,"open_issues":3,"watchers":0,"default_branch":"master","score":16.979485},{"id":216670989,"node_id":"MDEwOlJlcG9zaXRvcnkyMTY2NzA5ODk=","name":"monster_shop_1908","full_name":"ap2322/monster_shop_1908","private":false,"owner":{"login":"ap2322","id":26877629,"node_id":"MDQ6VXNlcjI2ODc3NjI5","avatar_url":"https://avatars0.githubusercontent.com/u/26877629?v=4","gravatar_id":"","url":"https://api.github.com/users/ap2322","html_url":"https://github.com/ap2322","followers_url":"https://api.github.com/users/ap2322/followers","following_url":"https://api.github.com/users/ap2322/following{/other_user}","gists_url":"https://api.github.com/users/ap2322/gists{/gist_id}","starred_url":"https://api.github.com/users/ap2322/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ap2322/subscriptions","organizations_url":"https://api.github.com/users/ap2322/orgs","repos_url":"https://api.github.com/users/ap2322/repos","events_url":"https://api.github.com/users/ap2322/events{/privacy}","received_events_url":"https://api.github.com/users/ap2322/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ap2322/monster_shop_1908","description":null,"fork":true,"url":"https://api.github.com/repos/ap2322/monster_shop_1908","forks_url":"https://api.github.com/repos/ap2322/monster_shop_1908/forks","keys_url":"https://api.github.com/repos/ap2322/monster_shop_1908/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ap2322/monster_shop_1908/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ap2322/monster_shop_1908/teams","hooks_url":"https://api.github.com/repos/ap2322/monster_shop_1908/hooks","issue_events_url":"https://api.github.com/repos/ap2322/monster_shop_1908/issues/events{/number}","events_url":"https://api.github.com/repos/ap2322/monster_shop_1908/events","assignees_url":"https://api.github.com/repos/ap2322/monster_shop_1908/assignees{/user}","branches_url":"https://api.github.com/repos/ap2322/monster_shop_1908/branches{/branch}","tags_url":"https://api.github.com/repos/ap2322/monster_shop_1908/tags","blobs_url":"https://api.github.com/repos/ap2322/monster_shop_1908/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ap2322/monster_shop_1908/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ap2322/monster_shop_1908/git/refs{/sha}","trees_url":"https://api.github.com/repos/ap2322/monster_shop_1908/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ap2322/monster_shop_1908/statuses/{sha}","languages_url":"https://api.github.com/repos/ap2322/monster_shop_1908/languages","stargazers_url":"https://api.github.com/repos/ap2322/monster_shop_1908/stargazers","contributors_url":"https://api.github.com/repos/ap2322/monster_shop_1908/contributors","subscribers_url":"https://api.github.com/repos/ap2322/monster_shop_1908/subscribers","subscription_url":"https://api.github.com/repos/ap2322/monster_shop_1908/subscription","commits_url":"https://api.github.com/repos/ap2322/monster_shop_1908/commits{/sha}","git_commits_url":"https://api.github.com/repos/ap2322/monster_shop_1908/git/commits{/sha}","comments_url":"https://api.github.com/repos/ap2322/monster_shop_1908/comments{/number}","issue_comment_url":"https://api.github.com/repos/ap2322/monster_shop_1908/issues/comments{/number}","contents_url":"https://api.github.com/repos/ap2322/monster_shop_1908/contents/{+path}","compare_url":"https://api.github.com/repos/ap2322/monster_shop_1908/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ap2322/monster_shop_1908/merges","archive_url":"https://api.github.com/repos/ap2322/monster_shop_1908/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ap2322/monster_shop_1908/downloads","issues_url":"https://api.github.com/repos/ap2322/monster_shop_1908/issues{/number}","pulls_url":"https://api.github.com/repos/ap2322/monster_shop_1908/pulls{/number}","milestones_url":"https://api.github.com/repos/ap2322/monster_shop_1908/milestones{/number}","notifications_url":"https://api.github.com/repos/ap2322/monster_shop_1908/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ap2322/monster_shop_1908/labels{/name}","releases_url":"https://api.github.com/repos/ap2322/monster_shop_1908/releases{/id}","deployments_url":"https://api.github.com/repos/ap2322/monster_shop_1908/deployments","created_at":"2019-10-21T21:45:25Z","updated_at":"2019-10-31T02:27:27Z","pushed_at":"2019-10-31T02:27:24Z","git_url":"git://github.com/ap2322/monster_shop_1908.git","ssh_url":"git@github.com:ap2322/monster_shop_1908.git","clone_url":"https://github.com/ap2322/monster_shop_1908.git","svn_url":"https://github.com/ap2322/monster_shop_1908","homepage":null,"size":410,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","score":13.544703}]}'
+    http_version: 
+  recorded_at: Sat, 21 Dec 2019 00:12:43 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/GitHubService/makes_an_api_call_to_search_repositiorties_with_given_params.yml
+++ b/spec/cassettes/GitHubService/makes_an_api_call_to_search_repositiorties_with_given_params.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/search/repositories?q=monster_shop%20in:name%20user:ap2322%20fork:true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 20 Dec 2019 23:42:28 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1576885408'
+      Cache-Control:
+      - no-cache
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - EB20:1E56:40D108:938173:5DFD5C63
+    body:
+      encoding: ASCII-8BIT
+      string: '{"total_count":2,"incomplete_results":false,"items":[{"id":218847867,"node_id":"MDEwOlJlcG9zaXRvcnkyMTg4NDc4Njc=","name":"monster_shop_final","full_name":"ap2322/monster_shop_final","private":false,"owner":{"login":"ap2322","id":26877629,"node_id":"MDQ6VXNlcjI2ODc3NjI5","avatar_url":"https://avatars0.githubusercontent.com/u/26877629?v=4","gravatar_id":"","url":"https://api.github.com/users/ap2322","html_url":"https://github.com/ap2322","followers_url":"https://api.github.com/users/ap2322/followers","following_url":"https://api.github.com/users/ap2322/following{/other_user}","gists_url":"https://api.github.com/users/ap2322/gists{/gist_id}","starred_url":"https://api.github.com/users/ap2322/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ap2322/subscriptions","organizations_url":"https://api.github.com/users/ap2322/orgs","repos_url":"https://api.github.com/users/ap2322/repos","events_url":"https://api.github.com/users/ap2322/events{/privacy}","received_events_url":"https://api.github.com/users/ap2322/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ap2322/monster_shop_final","description":null,"fork":false,"url":"https://api.github.com/repos/ap2322/monster_shop_final","forks_url":"https://api.github.com/repos/ap2322/monster_shop_final/forks","keys_url":"https://api.github.com/repos/ap2322/monster_shop_final/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ap2322/monster_shop_final/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ap2322/monster_shop_final/teams","hooks_url":"https://api.github.com/repos/ap2322/monster_shop_final/hooks","issue_events_url":"https://api.github.com/repos/ap2322/monster_shop_final/issues/events{/number}","events_url":"https://api.github.com/repos/ap2322/monster_shop_final/events","assignees_url":"https://api.github.com/repos/ap2322/monster_shop_final/assignees{/user}","branches_url":"https://api.github.com/repos/ap2322/monster_shop_final/branches{/branch}","tags_url":"https://api.github.com/repos/ap2322/monster_shop_final/tags","blobs_url":"https://api.github.com/repos/ap2322/monster_shop_final/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ap2322/monster_shop_final/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ap2322/monster_shop_final/git/refs{/sha}","trees_url":"https://api.github.com/repos/ap2322/monster_shop_final/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ap2322/monster_shop_final/statuses/{sha}","languages_url":"https://api.github.com/repos/ap2322/monster_shop_final/languages","stargazers_url":"https://api.github.com/repos/ap2322/monster_shop_final/stargazers","contributors_url":"https://api.github.com/repos/ap2322/monster_shop_final/contributors","subscribers_url":"https://api.github.com/repos/ap2322/monster_shop_final/subscribers","subscription_url":"https://api.github.com/repos/ap2322/monster_shop_final/subscription","commits_url":"https://api.github.com/repos/ap2322/monster_shop_final/commits{/sha}","git_commits_url":"https://api.github.com/repos/ap2322/monster_shop_final/git/commits{/sha}","comments_url":"https://api.github.com/repos/ap2322/monster_shop_final/comments{/number}","issue_comment_url":"https://api.github.com/repos/ap2322/monster_shop_final/issues/comments{/number}","contents_url":"https://api.github.com/repos/ap2322/monster_shop_final/contents/{+path}","compare_url":"https://api.github.com/repos/ap2322/monster_shop_final/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ap2322/monster_shop_final/merges","archive_url":"https://api.github.com/repos/ap2322/monster_shop_final/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ap2322/monster_shop_final/downloads","issues_url":"https://api.github.com/repos/ap2322/monster_shop_final/issues{/number}","pulls_url":"https://api.github.com/repos/ap2322/monster_shop_final/pulls{/number}","milestones_url":"https://api.github.com/repos/ap2322/monster_shop_final/milestones{/number}","notifications_url":"https://api.github.com/repos/ap2322/monster_shop_final/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ap2322/monster_shop_final/labels{/name}","releases_url":"https://api.github.com/repos/ap2322/monster_shop_final/releases{/id}","deployments_url":"https://api.github.com/repos/ap2322/monster_shop_final/deployments","created_at":"2019-10-31T19:45:19Z","updated_at":"2019-12-05T16:09:58Z","pushed_at":"2019-12-20T07:07:11Z","git_url":"git://github.com/ap2322/monster_shop_final.git","ssh_url":"git@github.com:ap2322/monster_shop_final.git","clone_url":"https://github.com/ap2322/monster_shop_final.git","svn_url":"https://github.com/ap2322/monster_shop_final","homepage":null,"size":239,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":3,"license":null,"forks":0,"open_issues":3,"watchers":0,"default_branch":"master","score":16.981054},{"id":216670989,"node_id":"MDEwOlJlcG9zaXRvcnkyMTY2NzA5ODk=","name":"monster_shop_1908","full_name":"ap2322/monster_shop_1908","private":false,"owner":{"login":"ap2322","id":26877629,"node_id":"MDQ6VXNlcjI2ODc3NjI5","avatar_url":"https://avatars0.githubusercontent.com/u/26877629?v=4","gravatar_id":"","url":"https://api.github.com/users/ap2322","html_url":"https://github.com/ap2322","followers_url":"https://api.github.com/users/ap2322/followers","following_url":"https://api.github.com/users/ap2322/following{/other_user}","gists_url":"https://api.github.com/users/ap2322/gists{/gist_id}","starred_url":"https://api.github.com/users/ap2322/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ap2322/subscriptions","organizations_url":"https://api.github.com/users/ap2322/orgs","repos_url":"https://api.github.com/users/ap2322/repos","events_url":"https://api.github.com/users/ap2322/events{/privacy}","received_events_url":"https://api.github.com/users/ap2322/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ap2322/monster_shop_1908","description":null,"fork":true,"url":"https://api.github.com/repos/ap2322/monster_shop_1908","forks_url":"https://api.github.com/repos/ap2322/monster_shop_1908/forks","keys_url":"https://api.github.com/repos/ap2322/monster_shop_1908/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ap2322/monster_shop_1908/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ap2322/monster_shop_1908/teams","hooks_url":"https://api.github.com/repos/ap2322/monster_shop_1908/hooks","issue_events_url":"https://api.github.com/repos/ap2322/monster_shop_1908/issues/events{/number}","events_url":"https://api.github.com/repos/ap2322/monster_shop_1908/events","assignees_url":"https://api.github.com/repos/ap2322/monster_shop_1908/assignees{/user}","branches_url":"https://api.github.com/repos/ap2322/monster_shop_1908/branches{/branch}","tags_url":"https://api.github.com/repos/ap2322/monster_shop_1908/tags","blobs_url":"https://api.github.com/repos/ap2322/monster_shop_1908/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ap2322/monster_shop_1908/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ap2322/monster_shop_1908/git/refs{/sha}","trees_url":"https://api.github.com/repos/ap2322/monster_shop_1908/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ap2322/monster_shop_1908/statuses/{sha}","languages_url":"https://api.github.com/repos/ap2322/monster_shop_1908/languages","stargazers_url":"https://api.github.com/repos/ap2322/monster_shop_1908/stargazers","contributors_url":"https://api.github.com/repos/ap2322/monster_shop_1908/contributors","subscribers_url":"https://api.github.com/repos/ap2322/monster_shop_1908/subscribers","subscription_url":"https://api.github.com/repos/ap2322/monster_shop_1908/subscription","commits_url":"https://api.github.com/repos/ap2322/monster_shop_1908/commits{/sha}","git_commits_url":"https://api.github.com/repos/ap2322/monster_shop_1908/git/commits{/sha}","comments_url":"https://api.github.com/repos/ap2322/monster_shop_1908/comments{/number}","issue_comment_url":"https://api.github.com/repos/ap2322/monster_shop_1908/issues/comments{/number}","contents_url":"https://api.github.com/repos/ap2322/monster_shop_1908/contents/{+path}","compare_url":"https://api.github.com/repos/ap2322/monster_shop_1908/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ap2322/monster_shop_1908/merges","archive_url":"https://api.github.com/repos/ap2322/monster_shop_1908/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ap2322/monster_shop_1908/downloads","issues_url":"https://api.github.com/repos/ap2322/monster_shop_1908/issues{/number}","pulls_url":"https://api.github.com/repos/ap2322/monster_shop_1908/pulls{/number}","milestones_url":"https://api.github.com/repos/ap2322/monster_shop_1908/milestones{/number}","notifications_url":"https://api.github.com/repos/ap2322/monster_shop_1908/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ap2322/monster_shop_1908/labels{/name}","releases_url":"https://api.github.com/repos/ap2322/monster_shop_1908/releases{/id}","deployments_url":"https://api.github.com/repos/ap2322/monster_shop_1908/deployments","created_at":"2019-10-21T21:45:25Z","updated_at":"2019-10-31T02:27:27Z","pushed_at":"2019-10-31T02:27:24Z","git_url":"git://github.com/ap2322/monster_shop_1908.git","ssh_url":"git@github.com:ap2322/monster_shop_1908.git","clone_url":"https://github.com/ap2322/monster_shop_1908.git","svn_url":"https://github.com/ap2322/monster_shop_1908","homepage":null,"size":410,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","score":13.551035}]}'
+    http_version: 
+  recorded_at: Fri, 20 Dec 2019 23:42:28 GMT
+recorded_with: VCR 5.0.0

--- a/spec/features/repos/repos_landing_spec.rb
+++ b/spec/features/repos/repos_landing_spec.rb
@@ -9,17 +9,8 @@ describe 'After a user signs in with GitHub, they see a repos page' do
     user = create(:user, login: 'mockuser', token: 'mock_token')
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
     visit '/repos'
-    
+
     expect(page).to have_css('#search')
     expect(page).to have_button('search')
   end
 end
-# User Story: As a user after I sign in with GitHub I see a landing page to select one of my github repos
-#
-# Epic: User Repo Search
-#
-# - [ ] There is a form to enter a repo name
-# - [ ] There is a button to submit your repo name
-# - [ ] Hits the GitHub Search API with the form params to search for a repo by name
-# - [ ] Sad path (No repo found)
-# - [ ] Tests written and passing

--- a/spec/features/repos/repos_landing_spec.rb
+++ b/spec/features/repos/repos_landing_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe 'After a user signs in with GitHub, they see a repos page' do
+  before(:all) do
+    OmniAuth.config.mock_auth[:github] = nil
+    stub_omniauth
+  end
+  it 'has a search bar to search for a repo' do
+    user = create(:user, login: 'mockuser', token: 'mock_token')
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    visit '/repos'
+    
+    expect(page).to have_css('#search')
+    expect(page).to have_button('search')
+  end
+end
+# User Story: As a user after I sign in with GitHub I see a landing page to select one of my github repos
+#
+# Epic: User Repo Search
+#
+# - [ ] There is a form to enter a repo name
+# - [ ] There is a button to submit your repo name
+# - [ ] Hits the GitHub Search API with the form params to search for a repo by name
+# - [ ] Sad path (No repo found)
+# - [ ] Tests written and passing

--- a/spec/features/repos/repos_search_spec.rb
+++ b/spec/features/repos/repos_search_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe 'A signed in User can search for their repos' do
+  before(:all) do
+    OmniAuth.config.mock_auth[:github] = nil
+    stub_omniauth
+  end
+  
+  it 'can search for a list of repos' do
+    user = create(:user, login: 'mockuser', token: 'mock_token')
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    visit '/repos'
+
+    fill_in 'search', with: 'monster_shop'
+    mock_repos_found = [
+      {
+        repo_name: 'monster_shop_1908',
+        owner: 'mockuser',
+        repo_id: 26877629,
+      },
+      {
+        repo_name: 'monster_shop_final',
+        owner: 'mockuser',
+        repo_id: 99999988,
+      },
+    ]
+    allow_any_instance_of(Repos::SearchController).to receive(:find_github_repos).and_return(mock_repos_found)
+    click_on 'search'
+
+    expect(current_path).to eq('/repos_search')
+
+    within '.found-repos' do
+      expect(page).to have_content('monster_shop_1908')
+      expect(page).to have_content('monster_shop_final')
+    end
+  end
+end

--- a/spec/features/repos/repos_search_spec.rb
+++ b/spec/features/repos/repos_search_spec.rb
@@ -5,26 +5,26 @@ describe 'A signed in User can search for their repos' do
     OmniAuth.config.mock_auth[:github] = nil
     stub_omniauth
   end
-  
-  it 'can search for a list of repos' do
-    user = create(:user, login: 'mockuser', token: 'mock_token')
+
+  it 'can search for a list of repos', :vcr do
+    user = create(:user, login: 'ap2322', token: ENV['GITHUB_TEST_TOKEN'])
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
     visit '/repos'
 
     fill_in 'search', with: 'monster_shop'
-    mock_repos_found = [
-      {
-        repo_name: 'monster_shop_1908',
-        owner: 'mockuser',
-        repo_id: 26877629,
-      },
-      {
-        repo_name: 'monster_shop_final',
-        owner: 'mockuser',
-        repo_id: 99999988,
-      },
-    ]
-    allow_any_instance_of(Repos::SearchController).to receive(:find_github_repos).and_return(mock_repos_found)
+    # mock_repos_found = [
+    #   {
+    #     repo_name: 'monster_shop_1908',
+    #     owner: 'mockuser',
+    #     repo_id: 26877629,
+    #   },
+    #   {
+    #     repo_name: 'monster_shop_final',
+    #     owner: 'mockuser',
+    #     repo_id: 99999988,
+    #   },
+    # ]
+    # allow_any_instance_of(Repos::SearchController).to receive(:find_github_repos).and_return(mock_repos_found)
     click_on 'search'
 
     expect(current_path).to eq('/repos_search')

--- a/spec/poros/repo_spec.rb
+++ b/spec/poros/repo_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe 'Repo' do
+  it 'makes a repo with a name' do
+    repo = Repo.new({other_info: 'notimportant', name: 'my_repo'})
+
+    expect(repo).to be_a(Repo)
+    expect(repo.name).to eq('my_repo')
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,7 +12,16 @@ require File.expand_path('../config/environment', __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'vcr'
+require 'webmock/rspec'
 
+VCR.configure do |config|
+  config.ignore_localhost = true
+  config.cassette_library_dir = 'spec/cassettes'
+  config.hook_into :webmock
+  config.configure_rspec_metadata!
+  config.filter_sensitive_data("<GITHUB_TEST_TOKEN>") { ENV['GITHUB_TEST_TOKEN'] }
+end
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe GitHubService do
+  scenario 'makes an instance of a GitHubService' do
+    github_service = GitHubService.new
+    expect(github_service).to be_a(GitHubService)
+  end
+
+  scenario 'makes an api call to search repositiorties with given params', :vcr do
+    user = create(:user, login: 'ap2322')
+    search_term = 'monster_shop'
+    github_service = GitHubService.new
+    repos_found_info = github_service.find_repos(user.login, search_term)
+
+    expect(repos_found_info).to have_key :items
+    expect(repos_found_info[:items]).to be_a(Array)
+    expect(repos_found_info[:items][0]).to have_key :name
+  end
+end


### PR DESCRIPTION
- Add form to search for repos
- User can fill in form, the params of the search then make a search query to GitHub api to find the repos for that signed-in user and it displays the repos on the page
- Tests written & passing, VCR enabled for GitHubService
- A few _questions_ around the routing of _same-page rendering for search params results_
- **Sad path NOT yet included**

Test coverage 82%

