### PR TITLE
Repos page Sad Path no repos found

### DIFF
--- a/app/facades/git_hub_repos_facade.rb
+++ b/app/facades/git_hub_repos_facade.rb
@@ -1,16 +1,24 @@
 class GitHubReposFacade
+  attr_reader :repos
+
   def initialize(login, search_term)
     @login = login
     @search_term = search_term
+    @repos = fetch_repos
   end
 
-  def repos
+  def fetch_repos
     service = GitHubService.new
     @repos_data ||= service.find_repos(login, search_term)
 
+    return [] unless @repos_data[:items]
     @repos_data[:items].map do |info|
       Repo.new(info)
     end
+  end
+
+  def bad_search
+    "No repo found, please search again"
   end
 
   private

--- a/app/views/repos/index.html.erb
+++ b/app/views/repos/index.html.erb
@@ -12,4 +12,6 @@
       </ul>
     <% end %>
   </section>
+<% elsif repos_found && repos_found.repos.empty? %>
+  <%= repos_found.bad_search %>
 <% end %>

--- a/spec/cassettes/A_signed_in_User_can_search_for_their_repos/shows_a_flash_message_no_repos_found_if_no_repos_found.yml
+++ b/spec/cassettes/A_signed_in_User_can_search_for_their_repos/shows_a_flash_message_no_repos_found_if_no_repos_found.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/search/repositories?q=$$%20in:name%20user:ap2322%20fork:true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Sun, 29 Dec 2019 17:01:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1577638940'
+      Cache-Control:
+      - no-cache
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - D6FE:27B5:514DCCE:A4BA00F:5E08DBE0
+    body:
+      encoding: ASCII-8BIT
+      string: '{"total_count":0,"incomplete_results":false,"items":[]}'
+    http_version: 
+  recorded_at: Sun, 29 Dec 2019 17:01:20 GMT
+recorded_with: VCR 5.0.0

--- a/spec/features/repos/repos_search_spec.rb
+++ b/spec/features/repos/repos_search_spec.rb
@@ -12,19 +12,6 @@ describe 'A signed in User can search for their repos' do
     visit '/repos'
 
     fill_in 'search', with: 'monster_shop'
-    # mock_repos_found = [
-    #   {
-    #     repo_name: 'monster_shop_1908',
-    #     owner: 'mockuser',
-    #     repo_id: 26877629,
-    #   },
-    #   {
-    #     repo_name: 'monster_shop_final',
-    #     owner: 'mockuser',
-    #     repo_id: 99999988,
-    #   },
-    # ]
-    # allow_any_instance_of(Repos::SearchController).to receive(:find_github_repos).and_return(mock_repos_found)
     click_on 'search'
 
     expect(current_path).to eq('/repos_search')
@@ -33,5 +20,16 @@ describe 'A signed in User can search for their repos' do
       expect(page).to have_content('monster_shop_1908')
       expect(page).to have_content('monster_shop_final')
     end
+  end
+
+  it 'shows a flash message no repos found if no repos found', :vcr do
+    user = create(:user, login: 'ap2322', token: ENV['GITHUB_TEST_TOKEN'])
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    visit '/repos'
+
+    fill_in 'search', with: '$$'
+    click_on 'search'
+
+    expect(page).to have_content("No repo found, please search again")
   end
 end


### PR DESCRIPTION
No repos found OR invalid searches for repos returns a sad path message to show on the repos search page.
GitHubReposFacade and Search Index views updated with sad path functionality.

Update tests, cassettes. 82.7% coverage