### PR TITLE
Cron Rake Task

### DIFF
--- a/lib/tasks/update_micro.rake
+++ b/lib/tasks/update_micro.rake
@@ -1,0 +1,6 @@
+desc "This task is called by the Heroku scheduler add-on"
+task :update_micro_database => :environment do
+  puts "Updating microservice database..."
+  Faraday.post(ENV['MICRO_SERVICE_UPDATE_ENDPOINT'])
+  puts "done."
+end


### PR DESCRIPTION
* Add Rake Task to make a post request to the microservice in order to trigger a database update on the microservice
* We will also have to add an environment variable named `MICRO_SERVICE_UPDATE_ENDPOINT`
* This task can be scheduled on with a heroku addon
Commands are as followed:
```
heroku addons:create scheduler:standard
heroku addons:open scheduler
```
