### PR TITLE
Add skylight gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ coverage
 
 # Ignore application configuration
 /config/application.yml
+/config/skylight.yml

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem 'faraday'
 gem 'figaro'
 gem 'omniauth-github'
 
+gem "skylight"
+
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,10 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    skylight (4.2.0)
+      skylight-core (= 4.2.0)
+    skylight-core (4.2.0)
+      activesupport (>= 4.2.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -268,6 +272,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   shoulda-matchers
   simplecov
+  skylight
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)


### PR DESCRIPTION
Add skylight gem to monitor the speed of our app

A skylight.yml file was needed and added to gitignore. If you need the skylight file I can give you the instructions or the file contents for it.